### PR TITLE
Fix test project path in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ permissions:
 env:
   # Configurações do Projeto
   SOLUTION_FILE: 'Postech.Fiap.Orders.sln'
-  TEST_PROJECT: 'test/Postech.Fiap.Orders.WebApi.UnitTest'
+  TEST_PROJECT: 'test/Postech.Fiap.Orders.WebApi.UnitTests'
   DOCKERFILE_PATH: 'src/Postech.Fiap.Orders.WebApi/Dockerfile'
   DOCKER_IMAGE_NAME: 'myfood-orders-webapi'
   COVERAGE_FILE: 'coverage.xml'


### PR DESCRIPTION
Updated the `TEST_PROJECT` path in the GitHub Actions deploy workflow to match the correct directory name. This ensures the workflow can locate and execute unit tests successfully.